### PR TITLE
Fix Maven configuration to compile with Java 21

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <java.version>21</java.version>
         <spring.boot.version>3.2.4</spring.boot.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
     </properties>
 
     <dependencyManagement>
@@ -83,8 +84,17 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Summary
- configure the Maven compiler plugin to compile with Java 21 using the release flag
- set the Spring Boot Maven plugin version so Maven resolves the plugin without warnings

## Testing
- ./mvnw -q clean test *(fails: unable to download dependencies in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5691556808330a5bc484c31d315ff